### PR TITLE
Image not visible if componentWillReceiveProps is called before the layout is measured

### DIFF
--- a/ParallaxImage.js
+++ b/ParallaxImage.js
@@ -38,6 +38,7 @@ var ParallaxImage = React.createClass({
       offset: 0,
       height: 0,
       width:  0,
+      measured: false,
     };
   },
 
@@ -54,7 +55,9 @@ var ParallaxImage = React.createClass({
   },
 
   componentWillReceiveProps: function(nextProps) {
-    this.isLayoutStale = !_.isEqual(nextProps, this.props);
+    if (this.state.measured === true) {
+      this.isLayoutStale = !_.isEqual(nextProps, this.props);
+    }
   },
 
   handleMeasure: function(ox, oy, width, height, px, py) {
@@ -63,6 +66,7 @@ var ParallaxImage = React.createClass({
       offset: py,
       height,
       width,
+      measured: true,
     });
   },
 


### PR DESCRIPTION
Hi,

First of all, thanks for sharing this package, it's nice and clean!

I came accross an issue while integrating it into an app.
I'm using [redux](https://github.com/gaearon/redux) and somehow `componentWillReceiveProps` was called with the same properties before `handleLayout` was called.
In that case the `width` and `height` were never set to their actual value, preventing the image from being visible.

So here I added a simple check to ensure that we've at least measured something once before setting `isLayoutStale` to `false`.

Let me know what you think.
