### PR TITLE
Support React 15.5+

### DIFF
--- a/ParallaxImage.js
+++ b/ParallaxImage.js
@@ -5,6 +5,8 @@
 
 var isEqual = require('lodash/lang/isEqual');
 var React = require('react');
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 var {
   View,
   Image,
@@ -16,11 +18,11 @@ var {
 
 var WINDOW_HEIGHT = Dimensions.get('window').height;
 
-var ParallaxImage = React.createClass({
+var ParallaxImage = createReactClass({
   propTypes: {
-    onPress:        React.PropTypes.func,
-    scrollY:        React.PropTypes.object,
-    parallaxFactor: React.PropTypes.number,
+    onPress:        PropTypes.func,
+    scrollY:        PropTypes.object,
+    parallaxFactor: PropTypes.number,
     imageStyle:     Image.propTypes.style,
     overlayStyle:   View.propTypes.style,
   },

--- a/ParallaxScrollViewComposition.js
+++ b/ParallaxScrollViewComposition.js
@@ -5,6 +5,8 @@
 
 var isArray = require('lodash/lang/isArray');
 var React = require('react');
+var createReactClass = require('create-react-class');
+var PropTypes = require('prop-types');
 var {
   Animated,
   ScrollView
@@ -31,9 +33,9 @@ var applyPropsToParallaxImages = function(children, props) {
 };
 
 
-var ParallaxScrollViewComposition = React.createClass({
+var ParallaxScrollViewComposition = createReactClass({
   propTypes: {
-    scrollViewComponent: React.PropTypes.func,
+    scrollViewComponent: PropTypes.func,
   },
 
   setNativeProps: function(nativeProps) {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
   },
   "homepage": "https://github.com/oblador/react-native-parallax",
   "dependencies": {
-    "lodash": "^3.10.1"
+    "create-react-class": "^15.6.2",
+    "lodash": "^3.10.1",
+    "prop-types": "^15.6.0"
   }
 }


### PR DESCRIPTION
To support React 15.5 and above, we use `PropTypes` from `prop-types` package instead of the React library, and do `createReactClass` from `create-react-class` package instead of the React library. See https://reactjs.org/blog/2017/04/07/react-v15.5.0.html